### PR TITLE
Ignore empty source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - A task to list the translation progress, `crowdinListTranslationProgress`.
 
+### Fixed
+- Ignore empty source files.
+
 ## [0.1.0] - 2021-07-26
 First alpha release.
 

--- a/src/main/java/org/zaproxy/gradle/crowdin/internal/SourceFilesUploader.java
+++ b/src/main/java/org/zaproxy/gradle/crowdin/internal/SourceFilesUploader.java
@@ -51,8 +51,12 @@ public class SourceFilesUploader {
 
     public void upload() {
         for (Source source : project.getSources()) {
-            localVfs.diff(remoteVfs, source.getCrowdinPath().getDir())
-                    .traverse(this::processResults);
+            String crowdinDir = source.getCrowdinPath().getDir();
+            if (localVfs.get(crowdinDir) == null) {
+                continue;
+            }
+
+            localVfs.diff(remoteVfs, crowdinDir).traverse(this::processResults);
         }
         nodesToRemove.forEach(node -> clientWrapper.removeItem(project.getId(), node.getData()));
     }

--- a/src/main/java/org/zaproxy/gradle/crowdin/internal/local/LocalVfs.java
+++ b/src/main/java/org/zaproxy/gradle/crowdin/internal/local/LocalVfs.java
@@ -32,6 +32,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.zaproxy.gradle.crowdin.internal.SimpleLogger;
 import org.zaproxy.gradle.crowdin.internal.VfsNode;
 import org.zaproxy.gradle.crowdin.internal.configuration.CrowdinProject;
 import org.zaproxy.gradle.crowdin.internal.configuration.FileSet;
@@ -39,7 +40,8 @@ import org.zaproxy.gradle.crowdin.internal.configuration.Source;
 
 public class LocalVfs extends VfsNode<LocalFile> {
 
-    public LocalVfs(Path projectDir, CrowdinProject crowdinProject) throws IOException {
+    public LocalVfs(Path projectDir, CrowdinProject crowdinProject, SimpleLogger logger)
+            throws IOException {
         PathBuilder pathBuilder = new PathBuilder(projectDir.getFileName().toString());
 
         for (Source source : crowdinProject.getSources()) {
@@ -47,6 +49,14 @@ public class LocalVfs extends VfsNode<LocalFile> {
 
             for (FileSet fileSet : source.getIncludes()) {
                 for (Path file : enumerateFiles(dir, fileSet.getPattern())) {
+                    if (Files.size(file) == 0) {
+                        logger.lifecycle(
+                                "Ignoring empty file in project {}: {}",
+                                crowdinProject.getId(),
+                                file);
+                        continue;
+                    }
+
                     addFile(pathBuilder, source, dir, fileSet, file);
                 }
             }

--- a/src/main/java/org/zaproxy/gradle/crowdin/tasks/CopyProjectTranslations.java
+++ b/src/main/java/org/zaproxy/gradle/crowdin/tasks/CopyProjectTranslations.java
@@ -26,7 +26,6 @@ import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
-import org.zaproxy.gradle.crowdin.internal.SimpleLogger;
 import org.zaproxy.gradle.crowdin.internal.TranslationsCopier;
 import org.zaproxy.gradle.crowdin.internal.configuration.CrowdinConfiguration;
 import org.zaproxy.gradle.crowdin.internal.configuration.CrowdinProject;
@@ -57,27 +56,9 @@ public abstract class CopyProjectTranslations extends CrowdinTask {
         Path baseDir = getProject().getProjectDir().toPath();
         Path packagesDir = getTranslationsPackageDirectory().getAsFile().get().toPath();
 
-        TranslationsCopier copier = new TranslationsCopier(packagesDir, new LoggerWrapper());
+        TranslationsCopier copier = new TranslationsCopier(packagesDir, getSimpleLogger());
         for (CrowdinProject project : configuration.getProjects()) {
             copier.copy(project, baseDir);
-        }
-    }
-
-    private class LoggerWrapper implements SimpleLogger {
-
-        @Override
-        public void lifecycle(String message, Object... objects) {
-            getLogger().lifecycle(message, objects);
-        }
-
-        @Override
-        public void warn(String message, Object... objects) {
-            getLogger().warn(message, objects);
-        }
-
-        @Override
-        public void error(String message, Object... objects) {
-            getLogger().error(message, objects);
         }
     }
 }

--- a/src/main/java/org/zaproxy/gradle/crowdin/tasks/CrowdinTask.java
+++ b/src/main/java/org/zaproxy/gradle/crowdin/tasks/CrowdinTask.java
@@ -42,6 +42,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.zaproxy.gradle.crowdin.CrowdinPluginException;
+import org.zaproxy.gradle.crowdin.internal.SimpleLogger;
 import org.zaproxy.gradle.crowdin.internal.configuration.ConfigurationException;
 import org.zaproxy.gradle.crowdin.internal.configuration.CrowdinConfiguration;
 import org.zaproxy.gradle.crowdin.internal.configuration.CrowdinProject;
@@ -54,6 +55,7 @@ public abstract class CrowdinTask extends DefaultTask {
 
     private CrowdinConfiguration crowdinConfiguration;
     private Client crowdinClient;
+    private SimpleLogger simpleLogger;
 
     protected CrowdinTask() {
         setGroup("Crowdin");
@@ -94,6 +96,14 @@ public abstract class CrowdinTask extends DefaultTask {
         return crowdinClient;
     }
 
+    @Internal
+    protected SimpleLogger getSimpleLogger() {
+        if (simpleLogger == null) {
+            simpleLogger = new LoggerWrapper(getLogger());
+        }
+        return simpleLogger;
+    }
+
     protected <R> R apiRequest(Function<Client, R> access) {
         try {
             return access.apply(getCrowdinClient());
@@ -106,7 +116,8 @@ public abstract class CrowdinTask extends DefaultTask {
 
     protected LocalVfs createLocalVfs(CrowdinProject crowdinProject) {
         try {
-            return new LocalVfs(getProject().getProjectDir().toPath(), crowdinProject);
+            return new LocalVfs(
+                    getProject().getProjectDir().toPath(), crowdinProject, getSimpleLogger());
         } catch (IOException e) {
             throw new CrowdinPluginException(
                     "An error occurred while enumerating the local files, cause: " + e.getMessage(),

--- a/src/main/java/org/zaproxy/gradle/crowdin/tasks/LoggerWrapper.java
+++ b/src/main/java/org/zaproxy/gradle/crowdin/tasks/LoggerWrapper.java
@@ -1,0 +1,48 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.crowdin.tasks;
+
+import java.util.Objects;
+import org.gradle.api.logging.Logger;
+import org.zaproxy.gradle.crowdin.internal.SimpleLogger;
+
+class LoggerWrapper implements SimpleLogger {
+
+    private final Logger logger;
+
+    LoggerWrapper(Logger logger) {
+        this.logger = Objects.requireNonNull(logger);
+    }
+
+    @Override
+    public void lifecycle(String message, Object... objects) {
+        logger.lifecycle(message, objects);
+    }
+
+    @Override
+    public void warn(String message, Object... objects) {
+        logger.warn(message, objects);
+    }
+
+    @Override
+    public void error(String message, Object... objects) {
+        logger.error(message, objects);
+    }
+}


### PR DESCRIPTION
Empty files don't have anything to localize and are rejected by Crowdin.
Handle no source files when enumerating and uploading.