### PR TITLE
Fix translations copy and prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
+## [0.2.1] - 2021-08-12
+### Fixed
+- Copy only translations that are contained in the export paths, if several export
+  paths had a common prefix some translations could be copied to incorrect directory.
 
 ## [0.2.0] - 2021-07-30
 ### Added
@@ -36,6 +38,6 @@ Added by the plugin:
  - `crowdinUploadSourceFiles` - Uploads the source files to Crowdin.
 
 
-[Unreleased]: https://github.com/zaproxy/gradle-plugin-crowdin/compare/v0.2.0...HEAD
+[0.2.1]: https://github.com/zaproxy/gradle-plugin-crowdin/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/zaproxy/gradle-plugin-crowdin/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/zaproxy/gradle-plugin-crowdin/compare/f935566adf4ba84f9a15def93643ef2d482ee2fc...v0.1.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
 }
 
 group = "org.zaproxy.gradle"
-version = "0.3.0-SNAPSHOT"
+version = "0.2.1"
 
 tasks.withType<PluginUnderTestMetadata>().configureEach {
     pluginClasspath.from(configurations.compileOnly)

--- a/src/main/java/org/zaproxy/gradle/crowdin/internal/TranslationsCopier.java
+++ b/src/main/java/org/zaproxy/gradle/crowdin/internal/TranslationsCopier.java
@@ -82,7 +82,7 @@ public class TranslationsCopier {
     private void copyFiles(
             ZipFile translations, DirFilenamePair exportPattern, Path baseOutputDir) {
         String path = normalizeDir(exportPattern.getDir());
-        int idx = path.length() + 1;
+        int idx = path.length();
         translations.stream()
                 .filter(e -> e.getName().startsWith(path))
                 .forEach(
@@ -110,6 +110,6 @@ public class TranslationsCopier {
     }
 
     private static String normalizeDir(String dir) {
-        return dir.substring(1, dir.length());
+        return dir.substring(1, dir.length()) + "/";
     }
 }


### PR DESCRIPTION
Copy only translations that are contained in the export paths, if
several export paths had a common prefix some translations could be
copied to incorrect directory.
Update version and changelog for release.