### PR TITLE
Reinstate configuration and prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2023-01-25
 ### Changed
 - Recommended minimum Gradle version is now 7.5.1.
 - The minimum Java version is 11.
@@ -44,7 +44,7 @@ Added by the plugin:
  - `crowdinUploadSourceFiles` - Uploads the source files to Crowdin.
 
 
-[Unreleased]: https://github.com/zaproxy/gradle-plugin-crowdin/compare/v0.2.1...HEAD
+[0.3.0]: https://github.com/zaproxy/gradle-plugin-crowdin/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/zaproxy/gradle-plugin-crowdin/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/zaproxy/gradle-plugin-crowdin/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/zaproxy/gradle-plugin-crowdin/compare/f935566adf4ba84f9a15def93643ef2d482ee2fc...v0.1.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ repositories {
 }
 
 group = "org.zaproxy.gradle"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0"
 
 val shadowImplementation by configurations.creating
 configurations["compileOnly"].extendsFrom(shadowImplementation)
@@ -107,4 +107,11 @@ val shadowJarTask = tasks.named<ShadowJar>("shadowJar") {
     dependsOn(relocateShadowJar)
     archiveClassifier.set("")
     configurations = listOf(shadowImplementation)
+}
+
+configurations {
+    artifacts {
+        runtimeElements(shadowJarTask)
+        apiElements(shadowJarTask)
+    }
 }


### PR DESCRIPTION
Reinstate artifacts configuration to correctly use the shadowed JAR, which was expected to be picked automatically by newer version of Gradle Publish plugin.
Update version and changelog for release.