### PR TITLE
Revert to old plugin and prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2023-01-25
+### Fixed
+- Correctly include dependencies when publishing to the Gradle Plugin Portal.
+
 ## [0.3.0] - 2023-01-25
 ### Changed
 - Recommended minimum Gradle version is now 7.5.1.
@@ -44,6 +48,7 @@ Added by the plugin:
  - `crowdinUploadSourceFiles` - Uploads the source files to Crowdin.
 
 
+[0.3.1]: https://github.com/zaproxy/gradle-plugin-crowdin/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/zaproxy/gradle-plugin-crowdin/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/zaproxy/gradle-plugin-crowdin/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/zaproxy/gradle-plugin-crowdin/compare/v0.1.0...v0.2.0


### PR DESCRIPTION
Use older version of the Gradle Publish plugin, the newer version or the configuration is not including the dependencies when publishing.
Update version and changelog for release.