### PR TITLE
Add GitHub workflow to release the plugin

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -1,0 +1,20 @@
+name: Release Plugin
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - uses: gradle/gradle-build-action@v2
+      - run: ./gradlew publishPlugin
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.ZAPBOT_GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.ZAPBOT_GRADLE_PUBLISH_SECRET }}


### PR DESCRIPTION
Add workflow to publish the plugin to the Gradle Plugin Portal using zapbot's credentials.
Update Gradle Publish plugin to 1.1.0 and update its configuration.
Bundle the Crowdin API client as a fat JAR to properly declare other dependencies when using the newer version of Gradle Publish plugin.