### PR TITLE
Support the usage of Gradle configuration cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Recommended minimum Gradle version is now 8.8.
 
+### Fixed
+- Address configuration cache problems.
+
 ## [0.4.0] - 2024-05-07
 ### Added
 - Allow to filter out translated files when copying them.

--- a/src/main/java/org/zaproxy/gradle/crowdin/tasks/CopyProjectTranslations.java
+++ b/src/main/java/org/zaproxy/gradle/crowdin/tasks/CopyProjectTranslations.java
@@ -62,7 +62,7 @@ public abstract class CopyProjectTranslations extends CrowdinTask {
     @TaskAction
     void copy() {
         CrowdinConfiguration configuration = getCrowdinConfiguration();
-        Path baseDir = getProject().getProjectDir().toPath();
+        Path baseDir = getProjectLayout().getProjectDirectory().getAsFile().toPath();
         Path packagesDir = getTranslationsPackageDirectory().getAsFile().get().toPath();
 
         TranslationsCopier copier =

--- a/src/main/java/org/zaproxy/gradle/crowdin/tasks/CrowdinTask.java
+++ b/src/main/java/org/zaproxy/gradle/crowdin/tasks/CrowdinTask.java
@@ -32,7 +32,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
+import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -62,6 +64,11 @@ public abstract class CrowdinTask extends DefaultTask {
         setGroup("Crowdin");
 
         getConfigurationTokens().convention(Collections.emptyMap());
+    }
+
+    @Inject
+    protected ProjectLayout getProjectLayout() {
+        throw new UnsupportedOperationException();
     }
 
     @Input
@@ -118,7 +125,9 @@ public abstract class CrowdinTask extends DefaultTask {
     protected LocalVfs createLocalVfs(CrowdinProject crowdinProject) {
         try {
             return new LocalVfs(
-                    getProject().getProjectDir().toPath(), crowdinProject, getSimpleLogger());
+                    getProjectLayout().getProjectDirectory().getAsFile().toPath(),
+                    crowdinProject,
+                    getSimpleLogger());
         } catch (IOException e) {
             throw new CrowdinPluginException(
                     "An error occurred while enumerating the local files, cause: " + e.getMessage(),


### PR DESCRIPTION
In order to support the configuration cache, any build-time information must not be accessible during runtime.

In order to solve this I've provided the project root as an internal directory property to the base crowdin task.
This way this directory is not resolved during runtime and configuration cache will work.

Fixes #28 